### PR TITLE
change virus uptake amount to match comments

### DIFF
--- a/CBIABM3.0 V2.0v5_PublishedV2
+++ b/CBIABM3.0 V2.0v5_PublishedV2
@@ -461,7 +461,7 @@ let p max-one-of neighbors [T1IFN + P/DAMPS]  ;; or neighbors4
     set size 1
     ;; of virus, uses local variable "q" to represent amount of virus eaten (avoid negative values)
     if extracellular-virus > 0
-     [let q max list 0 (extracellular-virus - 10) ;; currently set as arbitrary 10 amount of extracellular virus eaten per step
+     [let q min list 10 extracellular-virus ;; currently set as arbitrary 10 amount of extracellular virus eaten per step
       set extracellular-virus extracellular-virus - q
       set virus-eaten virus-eaten + q
      ]


### PR DESCRIPTION
The viral uptake formula disagrees with the comment. This changes the formula to agree with the comment.

There doesn't seem to be a noticeable change to the simulation outcome from this change, which might say something about identifiability in ABMs. :man_shrugging: